### PR TITLE
feat: emeritus command implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,3 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vscode/
-package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.vscode/
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+package-lock=false

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 MIT License
 
-Copyright (c) 2025 Fastify
+Copyright (c) 2025 The Fastify Team
+
+The Fastify team members are listed at https://github.com/fastify/fastify#team
+and in the README file.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # org-admin
 Utilities to handle the organization's permissions
+
+## Installation
+
+```bash
+npm install @fastify-org/org-admin
+```
+
+## Commands
+
+### Onboard a user
+
+```bash
+npx @fastify-org/org-admin onboard <username> --org <org> [--dry-run]
+```
+
+### Offboard a user
+
+```bash
+npx @fastify-org/org-admin offboard <username> --org <org> [--dry-run]
+```
+
+### Check emeritus members
+
+This command checks the last contribution date of members
+and marks them as emeritus if they haven't contributed in the last 12 months.
+
+```bash
+npx @fastify-org/org-admin emeritus --org <org> [--dry-run]
+```
+
+## License
+
+Licensed under [MIT](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -11,23 +11,20 @@ npm install @fastify-org/org-admin
 
 ### Onboard a user
 
-```bash
-npx @fastify-org/org-admin onboard <username> --org <org> [--dry-run]
-```
+- [ ] TODO
 
 ### Offboard a user
 
-```bash
-npx @fastify-org/org-admin offboard <username> --org <org> [--dry-run]
-```
+- [ ] TODO
 
 ### Check emeritus members
 
-This command checks the last contribution date of members
-and marks them as emeritus if they haven't contributed in the last 12 months.
+This command checks the last contribution date of org's members.
+It creates an issue listing the users that have been inactive for more than a specified number of months.
+
 
 ```bash
-npx @fastify-org/org-admin emeritus --org <org> [--dry-run]
+node --env-file=.env index.js emeritus --org <org> [--monthsInactiveThreshold] [--dryRun]
 ```
 
 ## License

--- a/commands/emeritus.js
+++ b/commands/emeritus.js
@@ -1,3 +1,10 @@
+/**
+ * Finds inactive members in an organization for the given number of months
+ * and opens an issue in the repository to propose moving them to the emeritus team.
+ * @param {{ client: import('../github-api.js').default, logger: import('pino').Logger }} deps
+ * @param {{ org: string, monthsInactiveThreshold: number, dryRun: boolean }} options
+ * @returns {Promise<void>}
+ */
 export default async function emeritus ({ client, logger }, { org, monthsInactiveThreshold, dryRun }) {
   logger.info('Running emeritus command for organization: %s', org)
 

--- a/commands/emeritus.js
+++ b/commands/emeritus.js
@@ -1,0 +1,53 @@
+export default async function emeritus ({ client, logger }, { org, monthsInactiveThreshold, dryRun }) {
+  logger.info('Running emeritus command for organization: %s', org)
+
+  const orgData = await client.getOrgData(org)
+  logger.info('Organization ID %s', orgData.id)
+
+  const orgTeams = await client.getOrgChart(orgData)
+  logger.info('Total teams: %s', orgTeams.length)
+
+  const membersDetails = await client.getMembersDetails(orgData)
+  logger.info('Total members: %s', membersDetails.length)
+
+  if (monthsInactiveThreshold > 12) {
+    // Since `getMembersDetails` returns members active in the last 12 months,
+    // we need to run another query to get members without contributions in the last year.
+    const membersWithoutContribInLastYear = membersDetails.filter(item => !item.lastPR && !item.lastIssue && !item.lastCommit)
+
+    const yearsToRead = Math.ceil(monthsInactiveThreshold / 12)
+    logger.warn('The monthsInactiveThreshold is set to more than 12 months, reading contributions for %s years...', yearsToRead)
+    const olderContributions = await client.getOlderContributions(orgData, membersWithoutContribInLastYear, yearsToRead)
+
+    // ! TODO merge the results instead of appending
+    membersDetails.push(...olderContributions)
+  }
+
+  const usersThatShouldBeEmeritus = membersDetails.filter(isEmeritus(monthsInactiveThreshold))
+  logger.info('Total emeritus members found: %s', usersThatShouldBeEmeritus.length)
+
+  const emeritusTeam = orgTeams.find(team => team.slug === 'emeritus')
+  const currentEmeritusUsers = emeritusTeam.members.map(member => member.login)
+
+  const usersToAdd = usersThatShouldBeEmeritus.filter(user => currentEmeritusUsers.includes(user.user) === false)
+
+  if (dryRun) {
+    logger.info('[DRY RUN] Would run emeritus command')
+    console.log(usersToAdd)
+  } else {
+    // TODO Implement emeritus logic here
+    //   logger.info('Running emeritus command')
+  }
+}
+
+function isEmeritus (monthsInactiveThreshold) {
+  const now = new Date()
+  return function filter (member) {
+    const dates = [member.lastPR, member.lastIssue, member.lastCommit].filter(Boolean)
+    // If any contribution is within the threshold, user should NOT be emeritus
+    return !dates.some(date => {
+      const monthsDiff = (now.getFullYear() - date.getFullYear()) * 12 + (now.getMonth() - date.getMonth())
+      return monthsDiff <= monthsInactiveThreshold
+    })
+  }
+}

--- a/commands/offboard.js
+++ b/commands/offboard.js
@@ -1,3 +1,9 @@
+/**
+ * Offboards a user from the organization.
+ * @param {{ logger: import('pino').Logger }} deps
+ * @param {{ org: string, username: string, dryRun: boolean }} options
+ * @returns {Promise<void>}
+ */
 export default async function offboard ({ logger }, { username, dryRun }) {
   // Implement offboarding logic here
   if (dryRun) {

--- a/commands/offboard.js
+++ b/commands/offboard.js
@@ -1,0 +1,8 @@
+export default async function offboard ({ logger }, { username, dryRun }) {
+  // Implement offboarding logic here
+  if (dryRun) {
+    logger.info(`[DRY RUN] Would offboard user: ${username}`)
+  } else {
+    logger.info(`Offboarding user: ${username}`)
+  }
+}

--- a/commands/offboard.js
+++ b/commands/offboard.js
@@ -1,5 +1,5 @@
 /**
- * Offboards a user from the organization.
+ * Offboards a user from an organization.
  * @param {{ logger: import('pino').Logger }} deps
  * @param {{ org: string, username: string, dryRun: boolean }} options
  * @returns {Promise<void>}

--- a/commands/onboard.js
+++ b/commands/onboard.js
@@ -1,0 +1,13 @@
+export default async function onboard ({ client, logger }, { org, username, dryRun }) {
+  const orgId = await client.getOrgId(org)
+  logger.info('Organization ID %s', orgId)
+
+  const orgChart = await client.getOrgChart(org)
+
+  // TODO Implement onboarding logic here
+  if (dryRun) {
+    logger.info(`[DRY RUN] Would onboard user: ${username}`)
+  } else {
+    logger.info(`Onboarding user: ${username}`)
+  }
+}

--- a/commands/onboard.js
+++ b/commands/onboard.js
@@ -1,3 +1,9 @@
+/**
+ * Onboards a user to the organization.
+ * @param {{ client: import('../github-api.js').default, logger: import('pino').Logger }} deps
+ * @param {{ org: string, username: string, dryRun: boolean }} options
+ * @returns {Promise<void>}
+ */
 export default async function onboard ({ client, logger }, { org, username, dryRun }) {
   const orgId = await client.getOrgId(org)
   logger.info('Organization ID %s', orgId)

--- a/commands/onboard.js
+++ b/commands/onboard.js
@@ -1,5 +1,5 @@
 /**
- * Onboards a user to the organization.
+ * Onboards a user to an organization.
  * @param {{ client: import('../github-api.js').default, logger: import('pino').Logger }} deps
  * @param {{ org: string, username: string, dryRun: boolean }} options
  * @returns {Promise<void>}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+import neostandard from 'neostandard'
+
+export default neostandard({})

--- a/github-api.js
+++ b/github-api.js
@@ -185,6 +185,50 @@ export default class AdminClient {
 
     return membersData
   }
+
+  /**
+   * Add a user to a team in the organization using the REST API
+   * @param {string} org - The organization name
+   * @param {string} teamSlug - The team slug
+   * @param {string} username - The GitHub username to add
+   */
+  async addUserToTeam (org, teamSlug, username) {
+    try {
+      const response = await this.restClient.teams.addOrUpdateMembershipForUserInOrg({
+        org,
+        team_slug: teamSlug,
+        username,
+        role: 'member',
+      })
+
+      this.logger.info({ username, teamSlug }, 'User added to team')
+      return response.data
+    } catch (error) {
+      this.logger.error({ username, teamSlug, error }, 'Failed to add user to team')
+      throw error
+    }
+  }
+
+  /**
+   * Remove a user from a team in the organization using the REST API
+   * @param {string} org - The organization name
+   * @param {string} teamSlug - The team slug
+   * @param {string} username - The GitHub username to remove
+   */
+  async removeUserFromTeam (org, teamSlug, username) {
+    try {
+      const response = await this.restClient.teams.removeMembershipForUserInOrg({
+        org,
+        team_slug: teamSlug,
+        username
+      })
+      this.logger.info({ username, teamSlug }, 'User removed from team')
+      return response.data
+    } catch (error) {
+      this.logger.error({ username, teamSlug, error }, 'Failed to remove user from team')
+      throw error
+    }
+  }
 }
 
 function transformGqlTeam ({ node }) {

--- a/github-api.js
+++ b/github-api.js
@@ -2,6 +2,7 @@ import { Octokit } from '@octokit/rest'
 import { graphql } from '@octokit/graphql'
 
 export default class AdminClient {
+  /** @param {import('pino').Logger} [logger] */
   constructor (logger) {
     if (!process.env.GITHUB_TOKEN) {
       throw new Error('GITHUB_TOKEN environment variable is not set')
@@ -187,10 +188,11 @@ export default class AdminClient {
   }
 
   /**
-   * Add a user to a team in the organization using the REST API
-   * @param {string} org - The organization name
-   * @param {string} teamSlug - The team slug
-   * @param {string} username - The GitHub username to add
+   * Add a user to a team in the organization using the REST API.
+   * @param {string} org - The organization name.
+   * @param {string} teamSlug - The team slug.
+   * @param {string} username - The GitHub username to add.
+   * @return {Promise<import('@octokit/openapi-types').components['schemas']['team-membership']>} The updated team data.
    */
   async addUserToTeam (org, teamSlug, username) {
     try {
@@ -210,10 +212,10 @@ export default class AdminClient {
   }
 
   /**
-   * Remove a user from a team in the organization using the REST API
-   * @param {string} org - The organization name
-   * @param {string} teamSlug - The team slug
-   * @param {string} username - The GitHub username to remove
+   * Removes a user from a team in the organization using the REST API.
+   * @param {string} org - The organization name.
+   * @param {string} teamSlug - The team slug.
+   * @param {string} username - The GitHub username to remove.
    */
   async removeUserFromTeam (org, teamSlug, username) {
     try {
@@ -231,13 +233,13 @@ export default class AdminClient {
   }
 
   /**
-   * Create a new issue in a repository using the REST API
-   * @param {string} owner - The repository owner (org or user)
-   * @param {string} repo - The repository name
-   * @param {string} title - The issue title
-   * @param {string} body - The issue body/description
-   * @param {Array<string>} [labels] - Optional array of labels
-   * @returns {Promise<Object>} - The created issue data
+   * Creates a new issue in a repository using the REST API.
+   * @param {string} owner - The repository owner (org or user).
+   * @param {string} repo - The repository name.
+   * @param {string} title - The issue title.
+   * @param {string} body - The issue body/description.
+   * @param {Array<string>} [labels] - Optional array of labels.
+   * @return {Promise<import('@octokit/openapi-types').components['schemas']['issue']>} The created issue data.
    */
   async createIssue (owner, repo, title, body, labels = []) {
     try {

--- a/github-api.js
+++ b/github-api.js
@@ -1,0 +1,279 @@
+import { Octokit } from '@octokit/rest'
+import { graphql } from '@octokit/graphql'
+
+export default class AdminClient {
+  constructor (logger) {
+    if (!process.env.GITHUB_TOKEN) {
+      throw new Error('GITHUB_TOKEN environment variable is not set')
+    }
+
+    this.logger = logger || console
+    this.restClient = new Octokit({
+      auth: process.env.GITHUB_TOKEN,
+      userAgent: 'fastify-org-admin-cli',
+    })
+
+    this.graphqlClient = graphql.defaults({
+      headers: {
+        authorization: `token ${process.env.GITHUB_TOKEN}`,
+      },
+    })
+  }
+
+  async getOrgData (orgName) {
+    const { organization } = await this.graphqlClient(`
+      query ($orgName: String!) {
+        organization(login: $orgName) {
+          id
+          name
+        }
+      }
+    `, { orgName })
+
+    return organization
+  }
+
+  async getOrgChart (orgData) {
+    let cursor = null
+    let hasNextPage = true
+    const teamsData = []
+
+    const teamsQuery = `
+      query ($cursor: String, $orgName: String!) {
+        organization(login: $orgName) {
+          teams(first: 100, after: $cursor) {
+            edges {
+              node {
+                id
+                name
+                slug
+                description
+                privacy
+                members(first: 100) {
+                  edges {
+                    node {
+                      login
+                      name
+                      email
+                    }
+                    role
+                  }
+                }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    `
+
+    while (hasNextPage) {
+      const variables = { cursor, orgName: orgData.name }
+      const teamsResponse = await this.graphqlClient(teamsQuery, variables)
+
+      const teams = teamsResponse.organization.teams.edges
+      teamsData.push(...teams.map(transformGqlTeam))
+
+      cursor = teamsResponse.organization.teams.pageInfo.endCursor
+      hasNextPage = teamsResponse.organization.teams.pageInfo.hasNextPage
+    }
+
+    return teamsData
+  }
+
+  async getMembersDetails (orgData) {
+    let cursor = null
+    let hasNextPage = true
+    const membersData = []
+
+    const membersQuery = `
+      query ($cursor: String, $orgName: String!, $orgId: ID, $fromDate: DateTime!, $toDate: DateTime!) {
+        organization(login: $orgName) {
+          membersWithRole(first: 15, after: $cursor) {
+            edges {
+              node {
+                login
+                name
+                contributionsCollection(
+                  organizationID: $orgId
+                  from: $fromDate
+                  to: $toDate
+                ) {
+                  pullRequestContributions(last: 1, orderBy: {direction: ASC}) {
+                    nodes {
+                      occurredAt
+                      pullRequest {
+                        url
+                      }
+                    }
+                  }
+                  issueContributions(last: 1, orderBy: {direction: ASC}) {
+                    nodes {
+                      occurredAt
+                      issue {
+                        url
+                      }
+                    }
+                  }
+                  commitContributionsByRepository(maxRepositories: 1) {
+                    contributions(last: 1, orderBy: {direction: ASC, field: OCCURRED_AT}) {
+                      nodes {
+                        repository {
+                          name
+                        }
+                        occurredAt
+                        url
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    `
+
+    // Calculate MAX date range supported by the GQL Service (from 1 year ago to today)
+    const toDate = new Date()
+    const fromDate = new Date()
+    fromDate.setFullYear(fromDate.getFullYear() - 1)
+
+    while (hasNextPage) {
+      const variables = {
+        cursor,
+        orgId: orgData.id,
+        orgName: orgData.name,
+        fromDate,
+        toDate
+      }
+
+      const membersResponse = await this.graphqlClient(membersQuery, variables)
+
+      const members = membersResponse.organization.membersWithRole.edges
+      membersData.push(...members.map(transformGqlMember))
+
+      cursor = membersResponse.organization.membersWithRole.pageInfo.endCursor
+      hasNextPage = membersResponse.organization.membersWithRole.pageInfo.hasNextPage
+    }
+
+    return membersData
+  }
+
+  async getOlderContributions (orgData, userList, yearsBack = 1) {
+    const oldContributionsQuery = `
+      query ($userId: String!, $orgId: ID, $from: DateTime!, $to: DateTime!) {
+        user(login: $userId) {
+          login
+          name
+          socialAccounts(last:4) {
+            nodes {
+              displayName
+              url
+              provider
+            }
+          }
+          contributionsCollection(
+            organizationID: $orgId
+            from: $from
+            to: $to
+          ) {
+            pullRequestContributions(last: 1, orderBy: {direction: ASC}) {
+              nodes {
+                occurredAt
+                pullRequest {
+                  url
+                }
+              }
+            }
+            issueContributions(last: 1, orderBy: {direction: ASC}) {
+              nodes {
+                occurredAt
+                issue {
+                  url
+                }
+              }
+            }
+            commitContributionsByRepository(maxRepositories: 1) {
+              contributions(last: 1, orderBy: {direction: ASC, field: OCCURRED_AT}) {
+                nodes {
+                  repository {
+                    name
+                  }
+                  occurredAt
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const membersData = []
+    for (let yearWindow = 0; yearWindow < yearsBack; yearWindow++) {
+      this.logger.debug('Fetching contributions for %s users in year window: %s', userList.length, yearWindow)
+
+      for (const staleUser of userList) {
+        const toDate = new Date()
+        toDate.setFullYear(toDate.getFullYear() - yearWindow)
+
+        const fromDate = new Date() // Always 1 year back
+        fromDate.setFullYear(toDate.getFullYear() - 1)
+
+        const variables = {
+          userId: staleUser.user,
+          orgId: orgData.id,
+          from: fromDate.toISOString(),
+          to: toDate.toISOString()
+        }
+
+        // TODO it is not neccessary to query again if the user has a contribution in the previous iteration
+        // ! TODO merge the results instead of querying again
+
+        this.logger.debug('Fetching contributions for user: %s from %s to %s', staleUser.user, variables.from, variables.to)
+        const contributionsResponse = await this.graphqlClient(oldContributionsQuery, variables)
+        membersData.push(transformGqlMember({ node: contributionsResponse.user }))
+      }
+    }
+
+    return membersData
+  }
+}
+
+function transformGqlTeam ({ node }) {
+  return {
+    id: node.id,
+    name: node.name,
+    slug: node.slug,
+    description: node.description,
+    privacy: node.privacy,
+    members: node.members.edges.map(({ node: member, role }) => ({
+      login: member.login,
+      name: member.name,
+      email: member.email,
+      role
+    }))
+  }
+}
+
+function transformGqlMember ({ node }) {
+  return {
+    user: node.login,
+    lastPR: toDate(node.contributionsCollection.pullRequestContributions?.nodes[0]?.occurredAt),
+    lastIssue: toDate(node.contributionsCollection.issueContributions?.nodes[0]?.occurredAt),
+    lastCommit: toDate(node.contributionsCollection.commitContributionsByRepository?.[0]?.contributions?.nodes?.[0]?.occurredAt),
+    socialAccounts: node.socialAccounts?.nodes,
+  }
+}
+
+function toDate (dateStr) {
+  return dateStr ? new Date(dateStr) : null
+}

--- a/github-api.js
+++ b/github-api.js
@@ -229,6 +229,32 @@ export default class AdminClient {
       throw error
     }
   }
+
+  /**
+   * Create a new issue in a repository using the REST API
+   * @param {string} owner - The repository owner (org or user)
+   * @param {string} repo - The repository name
+   * @param {string} title - The issue title
+   * @param {string} body - The issue body/description
+   * @param {Array<string>} [labels] - Optional array of labels
+   * @returns {Promise<Object>} - The created issue data
+   */
+  async createIssue (owner, repo, title, body, labels = []) {
+    try {
+      const response = await this.restClient.issues.create({
+        owner,
+        repo,
+        title,
+        body,
+        labels
+      })
+      this.logger.info({ owner, repo, title }, 'Issue created via REST API')
+      return response.data
+    } catch (error) {
+      this.logger.error({ owner, repo, title, error }, 'Failed to create issue via REST API')
+      throw error
+    }
+  }
 }
 
 function transformGqlTeam ({ node }) {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { parseArgs } from 'node:util'
+import pino from 'pino'
+
+import AdminClient from './github-api.js'
+import onboard from './commands/onboard.js'
+import offboard from './commands/offboard.js'
+import emeritus from './commands/emeritus.js'
+
+const logger = pino({
+  level: 'debug',
+  transport: {
+    target: 'pino-pretty',
+    options: {
+      colorize: true
+    }
+  }
+})
+
+const options = {
+  commands: ['onboard', 'offboard', 'emeritus'],
+  options: {
+    dryRun: { type: 'boolean', default: false },
+    username: { type: 'string', multiple: false, default: undefined },
+    org: { type: 'string', multiple: false, default: 'fastify' },
+    monthsInactiveThreshold: { type: 'string', multiple: false, default: '12' },
+  },
+  allowPositionals: true,
+}
+
+const parsed = parseArgs(options)
+
+const [command, ...positionals] = parsed.positionals || []
+const dryRun = parsed.values['dry-run'] || false
+const org = parsed.values.org
+const monthsInactiveThreshold = parseInt(parsed.values.monthsInactiveThreshold, 10) || 12
+
+if (!options.commands.includes(command)) {
+  logger.error(`Unknown command: ${command}`)
+  process.exit(1)
+}
+
+const client = new AdminClient(logger)
+const technicalOptions = { client, logger }
+
+switch (command) {
+  case 'onboard':
+  case 'offboard': {
+    const username = positionals[0]
+    if (!username) {
+      logger.error('Missing required username argument')
+      process.exit(1)
+    }
+
+    if (command === 'onboard') {
+      await onboard(technicalOptions, { username, dryRun, org })
+    } else {
+      await offboard(technicalOptions, { username, dryRun, org })
+    }
+    break
+  }
+  case 'emeritus':
+    await emeritus(technicalOptions, { dryRun, org, monthsInactiveThreshold })
+    break
+}

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const options = {
 const parsed = parseArgs(options)
 
 const [command, ...positionals] = parsed.positionals || []
-const dryRun = parsed.values['dry-run'] || false
+const dryRun = parsed.values.dryRun || false
 const org = parsed.values.org
 const monthsInactiveThreshold = parseInt(parsed.values.monthsInactiveThreshold, 10) || 12
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,16 @@
     "url": "https://github.com/fastify/org-admin/issues"
   },
   "homepage": "https://github.com/fastify/org-admin#readme",
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/fastify"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/fastify"
+    }
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "lint": "eslint . --ext .js,.ts",
     "lint:fix": "eslint . --ext .js,.ts --fix",
+    "try:emeritus": "node --env-file=.env index.js emeritus --monthsInactiveThreshold 24 --dryRun",
     "test": "exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@fastify/org-admin",
+  "version": "1.0.0",
+  "description": "Fastify Org Admin scripts",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "adminify": "index.js"
+  },
+  "devDependencies": {
+    "eslint": "^9.32.0",
+    "neostandard": "^0.12.2"
+  },
+  "dependencies": {
+    "@octokit/graphql": "^9.0.1",
+    "@octokit/rest": "^22.0.0",
+    "pino": "^9.7.0",
+    "pino-pretty": "^13.1.1"
+  },
+  "scripts": {
+    "lint": "eslint . --ext .js,.ts",
+    "lint:fix": "eslint . --ext .js,.ts --fix",
+    "test": "exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fastify/org-admin.git"
+  },
+  "author": "Eomm",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/fastify/org-admin/issues"
+  },
+  "homepage": "https://github.com/fastify/org-admin#readme",
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
This repo aims to implement some commands in order to automate most of our processess and control the access to our repos/packages for security reasons.

The commands will be:

- onboarding: add a new member to the org + npm
- offboarding: remove a member from the org + npm
- emeritus: check inactive users before running the offboarding process. It will create an issue pinging the inactive users

Now it is designed as a CLI in order to run it manually - to keep the human touch, but I would like to make it a GHA (triggered manually) at the end as final step (following PRs).


This PR implements the `emeritus` step to identify stale users.
Example of issue created with 2y of inactivity:
- https://github.com/fastify/org-admin/issues/2

I have removed the leads member from the equation because they contribute even without GH issue/PR/commits.

I will open other PRs to implement the other commands, I think this one is ready to be checked.

cc @Fdawgs 