### PR TITLE
refactor: explicitly import `node:process`

### DIFF
--- a/commands/offboard.js
+++ b/commands/offboard.js
@@ -1,3 +1,4 @@
+import { exit } from 'node:process'
 import { confirm } from './utils/input.js'
 import { removeFromNpm } from './utils/remove-from-npm.js'
 /**
@@ -10,7 +11,7 @@ export default async function offboard ({ logger, client }, { org, username, dry
   const joiningUser = await client.getUserInfo(username)
   if (!await confirm(`Are you sure you want to offboard ${joiningUser.login} [${joiningUser.name}] to ${org}?`)) {
     logger.warn('Aborting offboarding')
-    process.exit(0)
+    exit(0)
   }
 
   const orgData = await client.getOrgData(org)

--- a/commands/onboard.js
+++ b/commands/onboard.js
@@ -1,3 +1,4 @@
+import { exit } from 'node:process'
 import { confirm } from './utils/input.js'
 
 /**
@@ -10,7 +11,7 @@ export default async function onboard ({ client, logger }, { org, username, join
   const joiningUser = await client.getUserInfo(username)
   if (!await confirm(`Are you sure you want to onboard ${joiningUser.login} [${joiningUser.name}] to ${org}?`)) {
     logger.warn('Aborting onboarding')
-    process.exit(0)
+    exit(0)
   }
 
   const orgData = await client.getOrgData(org)
@@ -23,7 +24,7 @@ export default async function onboard ({ client, logger }, { org, username, join
   const wrongInputTeams = joiningTeams.difference(teamSlugs)
   if (wrongInputTeams.size) {
     logger.error('Team %s not found in organization %s', [...wrongInputTeams], org)
-    process.exit(1)
+    exit(1)
   }
 
   if (dryRun) {

--- a/commands/utils/input.js
+++ b/commands/utils/input.js
@@ -1,3 +1,4 @@
+import { stdin, stdout } from 'node:process'
 import readline from 'node:readline/promises'
 
 export async function confirm (q) {
@@ -7,8 +8,8 @@ export async function confirm (q) {
 
 export async function askForInput (message) {
   const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
+    input: stdin,
+    output: stdout
   })
   const answer = await rl.question(message)
   rl.close()

--- a/commands/utils/remove-from-npm.js
+++ b/commands/utils/remove-from-npm.js
@@ -1,9 +1,10 @@
+import { env } from 'node:process'
 import { spawn } from 'node:child_process'
 import { askForInput } from './input.js'
 
 function runSpawn (cmd, args) {
   return new Promise((resolve, reject) => {
-    const cli = spawn(cmd, args, { env: process.env })
+    const cli = spawn(cmd, args, { env })
     cli.stdout.setEncoding('utf8')
     cli.stderr.setEncoding('utf8')
 

--- a/github-api.js
+++ b/github-api.js
@@ -1,22 +1,23 @@
+import { env } from 'node:process'
 import { Octokit } from '@octokit/rest'
 import { graphql } from '@octokit/graphql'
 
 export default class AdminClient {
   /** @param {import('pino').Logger} [logger] */
   constructor (logger) {
-    if (!process.env.GITHUB_TOKEN) {
+    if (!env.GITHUB_TOKEN) {
       throw new Error('GITHUB_TOKEN environment variable is not set')
     }
 
     this.logger = logger || console
     this.restClient = new Octokit({
-      auth: process.env.GITHUB_TOKEN,
+      auth: env.GITHUB_TOKEN,
       userAgent: 'fastify-org-admin-cli',
     })
 
     this.graphqlClient = graphql.defaults({
       headers: {
-        authorization: `token ${process.env.GITHUB_TOKEN}`,
+        authorization: `token ${env.GITHUB_TOKEN}`,
       },
     })
   }


### PR DESCRIPTION
This PR improves static analysis by explicitly importing `node:process` rather than relying on the global `process`. Helps provide better type inference for TypeScript and autocomplete and error detection for IntelliSense in VS Code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
