### PR TITLE
ci: set permissions at workflow level

### DIFF
--- a/.github/workflows/emeritus-check.yml
+++ b/.github/workflows/emeritus-check.yml
@@ -14,7 +14,7 @@ jobs:
   emeritus-check:
     permissions:
       # Required to read repository contents
-      contents: write
+      contents: read
       # Required to create issues
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/emeritus-check.yml
+++ b/.github/workflows/emeritus-check.yml
@@ -8,13 +8,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  # Required to read repository contents
   contents: read
-  # Required to create issues
-  issues: write
 
 jobs:
   emeritus-check:
+    permissions:
+      # Required to read repository contents
+      contents: write
+      # Required to create issues
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/emeritus-check.yml
+++ b/.github/workflows/emeritus-check.yml
@@ -16,7 +16,7 @@ jobs:
       # Required to read repository contents
       contents: read
       # Required to create issues
-      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This change stops security tools like step-security from complaining and allows us to enforce read only by default which we have in all other repos.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
