### PR TITLE
ci: disable caching

### DIFF
--- a/.github/workflows/emeritus-check.yml
+++ b/.github/workflows/emeritus-check.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          check-latest: true
           node-version: "24"
-          cache: "npm"
 
       - name: Install dependencies
         run: npm i --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@fastify/org-admin",
   "version": "1.0.0",
   "description": "Fastify Org Admin scripts",
+  "private": true,
   "main": "index.js",
   "type": "module",
   "bin": {
@@ -42,8 +43,5 @@
       "type": "opencollective",
       "url": "https://opencollective.com/fastify"
     }
-  ],
-  "publishConfig": {
-    "access": "public"
-  }
+  ]
 }


### PR DESCRIPTION
Package-lock is required to use the caching feature of `actions/setup-node`. See: https://github.com/fastify/org-admin/actions/runs/19744227114

This PR disables caching.

Have also removed publishConfig as this probably won't be published to npm as it's an app/tool, not a module, just like our website repo.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
