### PR TITLE
fix: show npm handle

### DIFF
--- a/commands/offboard.js
+++ b/commands/offboard.js
@@ -49,20 +49,21 @@ export default async function offboard ({ logger, client }, { org, username, dry
     ...userTeams
   ]
 
+  const npmHandle = joiningUser.socialAccounts.nodes?.find(account => account.provider === 'NPM')?.displayName ?? joiningUser.login
   for (const team of userNpmTeams) {
     if (dryRun) {
-      logger.warn('[DRY RUN] This user %s will be removed from NPM team %s', joiningUser.login, team.slug)
+      logger.warn('[DRY RUN] This user %s will be removed from NPM team %s', npmHandle, team.slug)
       continue
     }
 
     try {
-      logger.debug('Removing %s from NPM team %s', joiningUser.login, team.slug)
-      await removeFromNpm(org, team.slug, joiningUser.login)
-      logger.info('Removed %s from NPM team %s', joiningUser.login, team.slug)
+      logger.debug('Removing %s from NPM team %s', npmHandle, team.slug)
+      await removeFromNpm(org, team.slug, npmHandle)
+      logger.info('Removed %s from NPM team %s', npmHandle, team.slug)
     } catch (error) {
-      logger.error('Failed to remove %s from NPM team %s', joiningUser.login, team.slug)
+      logger.error('Failed to remove %s from NPM team %s', npmHandle, team.slug)
       logger.error(error)
     }
   }
-  logger.info('NPM offboarding completed for user %s ✅ ', joiningUser.login)
+  logger.info('NPM offboarding completed for user %s ✅ ', npmHandle)
 }

--- a/commands/onboard.js
+++ b/commands/onboard.js
@@ -39,6 +39,8 @@ export default async function onboard ({ client, logger }, { org, username, join
   logger.info('GitHub onboarding completed for user %s ✅ ', joiningUser.login)
 
   logger.warn('To complete the NPM onboarding, please following these steps:')
+  const npmHandle = joiningUser.socialAccounts.nodes?.find(account => account.provider === 'NPM')?.displayName ?? joiningUser.login
+
   // This step cannot be automated, there are no API to add members to an org on NPM
   logger.info('1. Invite the user to the organization on NPM: https://www.npmjs.com/org/%s/invite?track=existingOrgAddMembers', org)
   logger.info('2. Add the user to the relevant teams by using the commands:');
@@ -46,7 +48,7 @@ export default async function onboard ({ client, logger }, { org, username, join
     { slug: 'developers' }, // NPM has a default team for every org
     ...destinationTeams
   ].forEach(team => {
-    logger.info('npm team add @%s:%s %s', org, team.slug, joiningUser.login)
+    logger.info('npm team add @%s:%s %s', org, team.slug, npmHandle)
   })
-  logger.info('When it will be done, the NPM onboarding will be completed for user %s ✅ ', joiningUser.login)
+  logger.info('When it will be done, the NPM onboarding will be completed for user %s ✅ ', npmHandle)
 }


### PR DESCRIPTION
If the user sets the `npm` handle in their GH profile, that one will be used on the display message:

<img width="343" height="554" alt="image" src="https://github.com/user-attachments/assets/ed0d466b-502e-40c0-924f-6e07c36280cd" />

