### PR TITLE
fix: GHA permission

### DIFF
--- a/.github/workflows/emeritus-check.yml
+++ b/.github/workflows/emeritus-check.yml
@@ -13,10 +13,8 @@ permissions:
 jobs:
   emeritus-check:
     permissions:
-      # Required to read repository contents
       contents: read
-      # Required to create issues
-      issues: write
+      issues: read
     runs-on: ubuntu-latest
 
     steps:
@@ -36,5 +34,5 @@ jobs:
 
       - name: Run emeritus check
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORG_TOKEN }}
         run: node index.js emeritus --monthsInactiveThreshold 12 --org fastify

--- a/commands/emeritus.js
+++ b/commands/emeritus.js
@@ -50,7 +50,7 @@ export default async function emeritus ({ client, logger }, { org, monthsInactiv
   } else {
     if (usersToEmeritus.length > 0) {
       await client.createIssue(
-        orgData.name,
+        orgData.name.toLowerCase(),
         'org-admin',
         'Move to emeritus members',
       `The following users have been inactive for more than ${monthsInactiveThreshold} months

--- a/commands/emeritus.js
+++ b/commands/emeritus.js
@@ -57,7 +57,7 @@ export default async function emeritus ({ client, logger }, { org, monthsInactiv
         and should be added to the emeritus team to control the access to the Fastify organization
         and secure the organization's repositories:
 
-        ${usersToEmeritus.map(user => `- @${user.user}`).join('\n')}
+${usersToEmeritus.map(user => `- @${user.user}`).join('\n')}
 
         \nComment here if you don't want to be moved to emeritus team and confirm that your account
         is still monitored and secured.`,


### PR DESCRIPTION
In order to add/remove users we need an org token to call this endpoint:
https://docs.github.com/en/rest/teams/members?apiVersion=2022-11-28#add-or-update-team-membership-for-a-user

Tested here: https://github.com/fastify/org-admin/issues/26 and https://github.com/fastify/org-admin/issues/28
